### PR TITLE
Remove the license field from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,6 @@ setup(
     author='Jean-Benoist Leger',
     author_email='jb@leger.tf',
 
-    # Choose your license
-    license='MIT',
-
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are


### PR DESCRIPTION
The license field should only be used when no license classifier is
precise enough to described the license.